### PR TITLE
feat: TUIモードでの直接クリップボード統合機能とドキュメント更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,8 @@ go test ./internal/config -v -run TestMCPServerConfig
 
 - **Language**: Go (chosen for performance, single binary distribution, concurrency)
 - **LLM Integration**: HTTP API via Ollama (primary), LM Studio, vLLM
+- **UI Framework**: Bubble Tea (charmbracelet/bubbletea) for modern TUI
+- **Clipboard Integration**: github.com/atotto/clipboard for direct system clipboard access
 - **Recommended Models**:
   - Qwen2.5-Coder 32B/14B (primary)
   - DeepSeek-Coder-V2 16B (balanced)
@@ -142,6 +144,7 @@ go test ./internal/config -v -run TestMCPServerConfig
 - ✅ Enhanced CLI integration with backward compatibility
 - ✅ Intelligent search with AST-based code structure analysis
 - ✅ **Modern TUI integration** (Bubble Tea framework, theme system, interactive components)
+- ✅ **Direct clipboard integration** (system clipboard access for seamless copy operations)
 
 ## Development Priorities
 
@@ -182,6 +185,13 @@ vyb                                # Start interactive mode (TUI enabled by defa
 vyb chat                           # Start interactive mode explicitly
 vyb chat --no-tui                  # Start in legacy text mode
 vyb --no-tui                       # Force legacy mode for any command
+
+# TUI mode clipboard operations (during interactive session)
+# F2                               # Copy all chat history to clipboard
+# Right-click                      # Copy last assistant response to clipboard  
+# Ctrl+Y                           # Copy last assistant response to clipboard
+# Ctrl+E                           # Export chat history to file
+# Ctrl+P                           # Print chat history to stdout
 
 # Search and discovery
 vyb search <pattern>               # Search across project files
@@ -241,3 +251,4 @@ vyb mcp disconnect [server]        # Disconnect from MCP server
 
 - 🤖 Added a new memory to track project insights and development context
 - 🚀 Phase 4 completed: Achieved Claude Code feature parity with MCP, advanced search, persistent sessions, and streaming responses
+- 📋 Direct clipboard integration implemented for TUI mode with visual feedback and multiple copy mechanisms (F2, right-click, Ctrl+Y)

--- a/go.mod
+++ b/go.mod
@@ -5,29 +5,31 @@ go 1.20
 require github.com/spf13/cobra v1.9.1
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/bubbles v0.16.0 // indirect
-	github.com/charmbracelet/bubbletea v0.24.1 // indirect
+	github.com/charmbracelet/bubbletea v0.27.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/lipgloss v0.9.0 // indirect
+	github.com/charmbracelet/lipgloss v0.13.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -13,6 +14,8 @@ github.com/charmbracelet/bubbletea v0.24.0 h1:l8PHrft/GIeikDPCUhQe53AJrDD8xGSn0A
 github.com/charmbracelet/bubbletea v0.24.0/go.mod h1:rK3g/2+T8vOSEkNHvtq40umJpeVYDn6bLaqbgzhL/hg=
 github.com/charmbracelet/bubbletea v0.24.1 h1:LpdYfnu+Qc6XtvMz6d/6rRY71yttHTP5HtrjMgWvixc=
 github.com/charmbracelet/bubbletea v0.24.1/go.mod h1:rK3g/2+T8vOSEkNHvtq40umJpeVYDn6bLaqbgzhL/hg=
+github.com/charmbracelet/bubbletea v0.27.1 h1:/yhaJKX52pxG4jZVKCNWj/oq0QouPdXycriDRA6m6r8=
+github.com/charmbracelet/bubbletea v0.27.1/go.mod h1:xc4gm5yv+7tbniEvQ0naiG9P3fzYhk16cTgDZQQW6YE=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
@@ -20,6 +23,8 @@ github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJ
 github.com/charmbracelet/lipgloss v0.6.0/go.mod h1:tHh2wr34xcHjC2HCXIlGSG1jaDF0S0atAUvBMP6Ppuk=
 github.com/charmbracelet/lipgloss v0.9.0 h1:BHIM7U4vX77xGEld8GrTKspBMtSv7j0wxPCH73nrdxE=
 github.com/charmbracelet/lipgloss v0.9.0/go.mod h1:h8KDyaivONasw1Bhb4nWiKlk4P1wHPly+3+3v6EFMmA=
+github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
+github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
@@ -32,6 +37,8 @@ github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkX
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
+github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
@@ -51,6 +58,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b h1:1XF24mVaiu7u+CFywTdcDo2ie1pzzhwjt6RHqzpMU34=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
+github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
+github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
@@ -74,9 +83,12 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/chat/session.go
+++ b/internal/chat/session.go
@@ -125,6 +125,36 @@ func (s *Session) GetMessageCount() int {
 	return len(s.messages)
 }
 
+// メッセージを送信してレスポンスを取得（TUI用）
+func (s *Session) SendMessage(userInput string) (string, error) {
+	// ユーザーメッセージを履歴に追加
+	s.messages = append(s.messages, llm.ChatMessage{
+		Role:    "user",
+		Content: userInput,
+	})
+
+	// チャットリクエストを作成
+	req := llm.ChatRequest{
+		Model:    s.model,
+		Messages: s.messages,
+	}
+
+	// LLMプロバイダーに送信
+	ctx := context.Background()
+	response, err := s.provider.Chat(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	// レスポンスを履歴に追加
+	s.messages = append(s.messages, llm.ChatMessage{
+		Role:    "assistant",
+		Content: response.Message.Content,
+	})
+
+	return response.Message.Content, nil
+}
+
 // MCPサーバーに接続
 func (s *Session) ConnectMCPServer(name string, config mcp.ClientConfig) error {
 	return s.mcpManager.ConnectServer(name, config)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,15 @@ func (c *Config) SetLogOutput(outputs []string) error {
 // TUI有効/無効を設定して保存する
 func (c *Config) SetTUIEnabled(enabled bool) error {
 	c.TUI.Enabled = enabled
+	// デフォルト値を設定
+	if c.TUI.Theme == "" {
+		c.TUI.Theme = "vyb"
+	}
+	if !c.TUI.ShowSpinner && !c.TUI.ShowProgress {
+		c.TUI.ShowSpinner = true
+		c.TUI.ShowProgress = true
+		c.TUI.Animation = true
+	}
 	return c.Save()
 }
 

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -1,0 +1,590 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/glkt/vyb-code/internal/chat"
+	"github.com/glkt/vyb-code/internal/config"
+)
+
+// チャット用TUIアプリ
+type ChatApp struct {
+	config       config.TUIConfig
+	theme        *ThemeManager
+	session      *chat.Session
+	viewport     viewport.Model
+	textarea     textarea.Model
+	messages     []ChatMessage
+	loading      bool
+	err          error
+	ready        bool
+	statusMsg    string // 一時的なステータスメッセージ
+	statusTimer  *time.Timer // ステータスメッセージタイマー
+}
+
+// チャットメッセージ
+type ChatMessage struct {
+	Role    string // "user" or "assistant"
+	Content string
+}
+
+// チャット応答メッセージ
+type ChatResponseMsg struct {
+	Content string
+	Error   error
+}
+
+// コピー完了メッセージ
+type CopyCompleteMsg struct {
+	Success bool
+	Message string
+}
+
+// ステータス消去メッセージ
+type ClearStatusMsg struct{}
+
+
+// 新しいチャットアプリを作成
+func NewChatApp(cfg config.TUIConfig, session *chat.Session) *ChatApp {
+	// ビューポート設定
+	vp := viewport.New(80, 20)
+	vp.YPosition = 0
+
+	// テキストエリア設定
+	ta := textarea.New()
+	ta.Placeholder = "メッセージを入力... (Tab/Ctrl+S/F1: 送信 / Enter: 改行)"
+	ta.Focus()
+	ta.Prompt = "> "
+	ta.CharLimit = 2000
+	ta.SetWidth(80)
+	ta.SetHeight(2)
+	ta.ShowLineNumbers = false
+	// シンプルな設定：Enterで改行を許可
+	ta.KeyMap.InsertNewline.SetEnabled(true)
+
+	return &ChatApp{
+		config:   cfg,
+		theme:    NewThemeManager(),
+		session:  session,
+		viewport: vp,
+		textarea: ta,
+		messages: []ChatMessage{
+			{
+				Role:    "assistant",
+				Content: "🎵 vyb へようこそ！何かお手伝いできることはありますか？",
+			},
+		},
+		loading: false,
+		ready:   false,
+	}
+}
+
+// Init implements tea.Model
+func (c *ChatApp) Init() tea.Cmd {
+	// 手動で画面をクリア（Alternative Screen無しでも美しい表示）
+	fmt.Print("\033[H\033[2J")
+	
+	return tea.Batch(
+		textarea.Blink,
+		c.updateViewport(),
+	)
+}
+
+// Update implements tea.Model
+func (c *ChatApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		// ターミナルサイズに基づいてコンポーネントサイズを調整
+		headerHeight := 2
+		helpHeight := 1
+		inputHeight := 3
+		
+		// ビューポートサイズを計算（余白を考慮）
+		c.viewport.Width = msg.Width - 4
+		c.viewport.Height = msg.Height - headerHeight - helpHeight - inputHeight - 2
+		
+		// テキストエリアの幅を調整
+		c.textarea.SetWidth(msg.Width - 4)
+		
+		c.ready = true
+		return c, c.updateViewport()
+
+	case tea.KeyMsg:
+		switch {
+		case msg.Type == tea.KeyCtrlC:
+			// 終了時にカーソルを復元
+			fmt.Print("\033[?25h") // カーソル表示
+			return c, tea.Quit
+		case msg.Type == tea.KeyTab:
+			// Tab でメッセージ送信（確実に動作）
+			if !c.loading && c.textarea.Value() != "" {
+				return c, c.sendMessage()
+			}
+			return c, nil
+		case msg.Type == tea.KeyCtrlS:
+			// Ctrl+S でメッセージ送信（安全）
+			if !c.loading && c.textarea.Value() != "" {
+				return c, c.sendMessage()
+			}
+			return c, nil
+		case msg.Type == tea.KeyF1:
+			// F1 でメッセージ送信（確実）
+			if !c.loading && c.textarea.Value() != "" {
+				return c, c.sendMessage()
+			}
+			return c, nil
+		case msg.String() == "ctrl+e":
+			// Ctrl+E で会話履歴をプレーンテキスト出力
+			return c, c.exportChat()
+		case msg.String() == "ctrl+p":
+			// Ctrl+P で会話履歴を標準出力に出力
+			return c, c.printChat()
+		case msg.Type == tea.KeyF2:
+			// F2 で全履歴をクリップボードにコピー
+			return c, c.copyAllToClipboard()
+		case msg.String() == "ctrl+y":
+			// Ctrl+Y で最後のレスポンスをクリップボードにコピー
+			return c, c.copyLastResponseToClipboard()
+		case msg.Type == tea.KeyEnter:
+			// 通常のEnterは改行（textareaのデフォルト動作）
+			if !c.loading {
+				var cmd tea.Cmd
+				c.textarea, cmd = c.textarea.Update(msg)
+				return c, cmd
+			}
+		case msg.String() == "shift+up":
+			// Shift+上矢印で3行上にスクロール
+			c.viewport.LineUp(3)
+			return c, nil
+		case msg.String() == "shift+down":
+			// Shift+下矢印で3行下にスクロール
+			c.viewport.LineDown(3)
+			return c, nil
+		case msg.Type == tea.KeyPgUp:
+			// Page Upでフルページ上にスクロール
+			c.viewport.ViewUp()
+			return c, nil
+		case msg.Type == tea.KeyPgDown:
+			// Page Downでフルページ下にスクロール
+			c.viewport.ViewDown()
+			return c, nil
+		case msg.String() == "ctrl+u":
+			// Ctrl+U で大きく上にスクロール（画面の3/4）
+			scrollLines := (c.viewport.Height * 3) / 4
+			if scrollLines < 5 {
+				scrollLines = 5
+			}
+			c.viewport.LineUp(scrollLines)
+			return c, nil
+		case msg.String() == "ctrl+d":
+			// Ctrl+D で大きく下にスクロール（画面の3/4）
+			scrollLines := (c.viewport.Height * 3) / 4
+			if scrollLines < 5 {
+				scrollLines = 5
+			}
+			c.viewport.LineDown(scrollLines)
+			return c, nil
+		case msg.String() == "ctrl+home":
+			// Ctrl+Home で一番上にスクロール
+			c.viewport.GotoTop()
+			return c, nil
+		case msg.String() == "ctrl+end":
+			// Ctrl+End で一番下にスクロール
+			c.viewport.GotoBottom()
+			return c, nil
+		case msg.Type == tea.KeyEsc:
+			if c.loading {
+				// 処理をキャンセル（今回は簡略化）
+				c.loading = false
+			}
+		default:
+			// その他のキー入力はテキストエリアに渡す
+			if !c.loading {
+				var cmd tea.Cmd
+				c.textarea, cmd = c.textarea.Update(msg)
+				cmds = append(cmds, cmd)
+			}
+		}
+
+	case tea.MouseMsg:
+		switch msg.Type {
+		case tea.MouseWheelUp:
+			// マウスホイール上で5行スクロール
+			c.viewport.LineUp(5)
+			return c, nil
+		case tea.MouseWheelDown:
+			// マウスホイール下で5行スクロール
+			c.viewport.LineDown(5)
+			return c, nil
+		case tea.MouseRight:
+			// 右クリックで最後のレスポンスをクリップボードにコピー
+			return c, c.copyLastResponseToClipboard()
+		}
+
+	case ChatResponseMsg:
+		c.loading = false
+		if msg.Error != nil {
+			c.err = msg.Error
+			c.messages = append(c.messages, ChatMessage{
+				Role:    "assistant",
+				Content: "エラー: " + msg.Error.Error(),
+			})
+		} else {
+			c.messages = append(c.messages, ChatMessage{
+				Role:    "assistant",
+				Content: msg.Content,
+			})
+		}
+		cmds = append(cmds, c.updateViewport())
+
+	case CopyCompleteMsg:
+		// コピー完了メッセージを表示
+		c.statusMsg = msg.Message
+		// 3秒後にステータスを消去
+		return c, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return ClearStatusMsg{}
+		})
+
+	case ClearStatusMsg:
+		// ステータスメッセージをクリア
+		c.statusMsg = ""
+
+	default:
+		// その他のメッセージはviewportに渡す
+		var cmd tea.Cmd
+		c.viewport, cmd = c.viewport.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return c, tea.Batch(cmds...)
+}
+
+// View implements tea.Model
+func (c *ChatApp) View() string {
+	if !c.ready {
+		return "初期化中..."
+	}
+
+	// 計算されたサイズ
+	headerHeight := 2
+	helpHeight := 1
+	inputHeight := 3
+	
+	// 利用可能な高さを計算
+	availableHeight := c.viewport.Height + headerHeight + helpHeight + inputHeight
+	contentHeight := availableHeight - headerHeight - helpHeight - inputHeight
+
+	// ヘッダー（固定）
+	header := lipgloss.NewStyle().
+		Height(headerHeight).
+		Render(c.theme.HeaderStyle().Render("🎵 vyb - AI コーディングアシスタント"))
+
+	// メッセージビュー（スクロール可能）
+	messagesView := lipgloss.NewStyle().
+		Height(contentHeight).
+		Render(c.viewport.View())
+
+	// 入力エリア（固定）
+	var inputArea string
+	if c.loading {
+		inputArea = lipgloss.NewStyle().
+			Height(inputHeight).
+			Render(c.theme.InfoStyle().Render("🤖 考え中..."))
+	} else {
+		inputArea = lipgloss.NewStyle().
+			Height(inputHeight).
+			Render(c.textarea.View())
+	}
+
+	// ステータスメッセージまたはヘルプテキスト（固定）
+	var helpText string
+	if c.statusMsg != "" {
+		helpText = c.theme.SuccessStyle().Render(c.statusMsg)
+	} else {
+		helpText = c.theme.InfoStyle().Render("Tab/F1: 送信 | Enter: 改行 | F2: 全履歴コピー | 右クリック/Ctrl+Y: 最新回答コピー | Ctrl+C: 終了")
+	}
+	
+	help := lipgloss.NewStyle().
+		Height(helpHeight).
+		Render(helpText)
+
+	// フレックスレイアウト
+	return lipgloss.NewStyle().
+		Width(c.viewport.Width).
+		Render(
+			lipgloss.JoinVertical(
+				lipgloss.Left,
+				header,
+				messagesView,
+				inputArea,
+				help,
+			),
+		)
+}
+
+// メッセージを送信
+func (c *ChatApp) sendMessage() tea.Cmd {
+	userMessage := strings.TrimSpace(c.textarea.Value())
+	if userMessage == "" {
+		return nil
+	}
+
+	// ユーザーメッセージを追加
+	c.messages = append(c.messages, ChatMessage{
+		Role:    "user",
+		Content: userMessage,
+	})
+
+	// 入力をクリア
+	c.textarea.Reset()
+	c.loading = true
+
+	// LLM応答を取得（非同期）
+	return tea.Cmd(func() tea.Msg {
+		response, err := c.session.SendMessage(userMessage)
+		return ChatResponseMsg{
+			Content: response,
+			Error:   err,
+		}
+	})
+}
+
+// テキストを指定幅で折り返し（UTF-8対応）
+func (c *ChatApp) wrapText(text string, width int) string {
+	if width <= 10 {
+		return text
+	}
+
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		if utf8.RuneCountInString(line) <= width {
+			lines = append(lines, line)
+			continue
+		}
+
+		// 長い行を文字単位で分割
+		runes := []rune(line)
+		for len(runes) > width {
+			lines = append(lines, string(runes[:width]))
+			runes = runes[width:]
+		}
+		if len(runes) > 0 {
+			lines = append(lines, string(runes))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ビューポートを更新
+func (c *ChatApp) updateViewport() tea.Cmd {
+	var content strings.Builder
+	
+	// メッセージエリアの幅（余白を考慮）
+	messageWidth := c.viewport.Width - 4
+	if messageWidth < 40 {
+		messageWidth = 40 // 最小幅を確保
+	}
+
+	for i, msg := range c.messages {
+		var style lipgloss.Style
+		var prefix string
+
+		if msg.Role == "user" {
+			style = c.theme.InfoStyle()
+			prefix = "👤 あなた: "
+		} else {
+			style = c.theme.AccentStyle()
+			prefix = "🤖 vyb: "
+		}
+
+		// プレフィックス部分
+		content.WriteString(style.Render(prefix) + "\n")
+		
+		// メッセージ内容を折り返し処理（プレフィックス分をインデント）
+		wrappedContent := c.wrapText(msg.Content, messageWidth-4)
+		
+		// 各行にインデントを追加
+		indentedLines := []string{}
+		for _, line := range strings.Split(wrappedContent, "\n") {
+			indentedLines = append(indentedLines, "  "+line)
+		}
+		
+		content.WriteString(strings.Join(indentedLines, "\n"))
+		
+		// 最後のメッセージ以外は改行を2つ追加
+		if i < len(c.messages)-1 {
+			content.WriteString("\n\n")
+		} else {
+			// 最後のメッセージは1つの改行のみ（途切れ防止）
+			content.WriteString("\n")
+		}
+	}
+
+	// 新しいメッセージが追加された時だけ一番下に移動
+	currentContent := c.viewport.View()
+	newContent := content.String()
+	
+	c.viewport.SetContent(newContent)
+	
+	// コンテンツが変更された場合のみ最下部に移動
+	if currentContent != newContent {
+		c.viewport.GotoBottom()
+	}
+	
+	return nil
+}
+
+// 会話履歴をファイルにエクスポート
+func (c *ChatApp) exportChat() tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		timestamp := time.Now().Format("2006-01-02_15-04-05")
+		filename := fmt.Sprintf("vyb-chat_%s.txt", timestamp)
+		
+		var content strings.Builder
+		content.WriteString(fmt.Sprintf("vyb Chat Export - %s\n", time.Now().Format("2006-01-02 15:04:05")))
+		content.WriteString(strings.Repeat("=", 50) + "\n\n")
+		
+		for _, msg := range c.messages {
+			if msg.Role == "user" {
+				content.WriteString("👤 あなた:\n")
+			} else {
+				content.WriteString("🤖 vyb:\n")
+			}
+			content.WriteString(msg.Content + "\n\n")
+		}
+		
+		if err := os.WriteFile(filename, []byte(content.String()), 0644); err == nil {
+			c.messages = append(c.messages, ChatMessage{
+				Role:    "system",
+				Content: fmt.Sprintf("会話履歴を %s にエクスポートしました", filename),
+			})
+		}
+		
+		return CompleteMsg{}
+	})
+}
+
+// 会話履歴を標準出力に出力
+func (c *ChatApp) printChat() tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		fmt.Println("\n" + strings.Repeat("=", 50))
+		fmt.Println("vyb Chat History")
+		fmt.Println(strings.Repeat("=", 50))
+		
+		for _, msg := range c.messages {
+			if msg.Role == "user" {
+				fmt.Println("👤 あなた:")
+			} else {
+				fmt.Println("🤖 vyb:")
+			}
+			fmt.Println(msg.Content)
+			fmt.Println()
+		}
+		
+		fmt.Println(strings.Repeat("=", 50))
+		
+		return CompleteMsg{}
+	})
+}
+
+// 全履歴をクリップボードにコピー
+func (c *ChatApp) copyAllToClipboard() tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		var content strings.Builder
+		
+		for _, msg := range c.messages {
+			if msg.Role == "user" {
+				content.WriteString("あなた: " + msg.Content + "\n\n")
+			} else {
+				content.WriteString("vyb: " + msg.Content + "\n\n")
+			}
+		}
+		
+		err := clipboard.WriteAll(content.String())
+		if err != nil {
+			return CopyCompleteMsg{
+				Success: false,
+				Message: "❌ コピー失敗: " + err.Error(),
+			}
+		}
+		
+		return CopyCompleteMsg{
+			Success: true,
+			Message: "📋 全履歴をクリップボードにコピーしました",
+		}
+	})
+}
+
+// 最後のレスポンスをクリップボードにコピー
+func (c *ChatApp) copyLastResponseToClipboard() tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		// 最後のアシスタントメッセージを探す
+		for i := len(c.messages) - 1; i >= 0; i-- {
+			if c.messages[i].Role == "assistant" {
+				err := clipboard.WriteAll(c.messages[i].Content)
+				if err != nil {
+					return CopyCompleteMsg{
+						Success: false,
+						Message: "❌ コピー失敗: " + err.Error(),
+					}
+				}
+				
+				return CopyCompleteMsg{
+					Success: true,
+					Message: "📋 最新回答をクリップボードにコピーしました",
+				}
+			}
+		}
+		
+		return CopyCompleteMsg{
+			Success: false,
+			Message: "❌ コピー対象が見つかりません",
+		}
+	})
+}
+
+// コピー用に履歴を出力（選択しやすい形式）- 後方互換性のため保持
+func (c *ChatApp) printChatForCopy() tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		fmt.Println() // 空行
+		
+		for _, msg := range c.messages {
+			if msg.Role == "user" {
+				fmt.Printf("あなた: %s\n", msg.Content)
+			} else {
+				fmt.Printf("vyb: %s\n", msg.Content)
+			}
+			fmt.Println()
+		}
+		
+		return CompleteMsg{}
+	})
+}
+
+// 最後のレスポンスのみをコピー用に出力 - 後方互換性のため保持
+func (c *ChatApp) printLastResponse() tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		// 最後のアシスタントメッセージを探す
+		for i := len(c.messages) - 1; i >= 0; i-- {
+			if c.messages[i].Role == "assistant" {
+				fmt.Println() // 空行
+				fmt.Println(c.messages[i].Content)
+				fmt.Println() // 空行
+				break
+			}
+		}
+		
+		return CompleteMsg{}
+	})
+}


### PR DESCRIPTION
## 概要

- TUIモードでの直接クリップボード統合機能を実装
- github.com/atotto/clipboardを使用した直接クリップボード操作
- stdout経由のコピー方式から即座のクリップボード操作に置き換え
- 視覚的フィードバック機能付きの一時ステータスメッセージ

## 主な機能

- **F2**: 全チャット履歴をクリップボードにコピー
- **右クリック**: 最新のアシスタント回答をクリップボードにコピー
- **Ctrl+Y**: 最新のアシスタント回答をクリップボードにコピー
- **3秒自動消去**: ステータスメッセージの自動クリア機能

## ドキュメント更新

- CLAUDE.mdに技術スタックとして Bubble Tea フレームワークとクリップボード統合を追加
- Phase 4 完了機能として直接クリップボード統合を記載
- TUIモードでのキーバインド詳細を追加
- メモリーセクションにクリップボード機能実装の記録を追加

## テスト計画

- [x] F2キーでの全履歴コピー機能動作確認
- [x] 右クリックでの最新回答コピー機能動作確認  
- [x] Ctrl+Yでの最新回答コピー機能動作確認
- [x] ステータスメッセージの表示と自動消去確認
- [x] ドキュメント記載内容の正確性確認

TUIとstdoutの出力混在問題を解決し、よりスムーズなユーザー体験を実現。