### PR TITLE
Hotfix v1.0.1: Windows Syscall Compatibility

### DIFF
--- a/internal/input/reader.go
+++ b/internal/input/reader.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
-	"unsafe"
 
 	"golang.org/x/term"
 )
@@ -542,27 +540,7 @@ func (r *Reader) ReadMultiLine() (string, error) {
 	}
 }
 
-// 端末サイズを取得
-func getTerminalSize() (int, int) {
-	type winsize struct {
-		Row    uint16
-		Col    uint16
-		Xpixel uint16
-		Ypixel uint16
-	}
-
-	ws := &winsize{}
-	ret, _, _ := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(os.Stdout.Fd()),
-		uintptr(syscall.TIOCGWINSZ),
-		uintptr(unsafe.Pointer(ws)))
-
-	if int(ret) == -1 {
-		return 80, 24 // デフォルト値
-	}
-
-	return int(ws.Col), int(ws.Row)
-}
+// getTerminalSize は reader_unix.go と reader_windows.go で実装
 
 // リーダーのクリーンアップ
 func (r *Reader) Close() error {

--- a/internal/input/reader_unix.go
+++ b/internal/input/reader_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+// +build !windows
+
+package input
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// 端末サイズを取得 (Unix系専用)
+func getTerminalSize() (int, int) {
+	type winsize struct {
+		Row    uint16
+		Col    uint16
+		Xpixel uint16
+		Ypixel uint16
+	}
+
+	ws := &winsize{}
+	ret, _, _ := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(os.Stdout.Fd()),
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(ws)))
+
+	if int(ret) == -1 {
+		return 80, 24 // デフォルト値
+	}
+
+	return int(ws.Col), int(ws.Row)
+}

--- a/internal/input/reader_windows.go
+++ b/internal/input/reader_windows.go
@@ -1,0 +1,58 @@
+//go:build windows
+// +build windows
+
+package input
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32                       = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+)
+
+type consoleScreenBufferInfo struct {
+	Size              coord
+	CursorPosition    coord
+	Attributes        uint16
+	Window            smallRect
+	MaximumWindowSize coord
+}
+
+type coord struct {
+	X int16
+	Y int16
+}
+
+type smallRect struct {
+	Left   int16
+	Top    int16
+	Right  int16
+	Bottom int16
+}
+
+// 端末サイズを取得 (Windows専用)
+func getTerminalSize() (int, int) {
+	// 標準出力のハンドルを取得
+	handle := os.Stdout.Fd()
+
+	var csbi consoleScreenBufferInfo
+	ret, _, _ := procGetConsoleScreenBufferInfo.Call(
+		uintptr(handle),
+		uintptr(unsafe.Pointer(&csbi)),
+	)
+
+	if ret == 0 {
+		// エラーの場合はデフォルト値を返す
+		return 80, 24
+	}
+
+	// ウィンドウサイズを計算
+	width := int(csbi.Window.Right - csbi.Window.Left + 1)
+	height := int(csbi.Window.Bottom - csbi.Window.Top + 1)
+
+	return width, height
+}


### PR DESCRIPTION
## 🛠️ Windows Compatibility Hotfix

Resolves the Windows build failure that prevented complete v1.0.0 release.

### Problem
GitHub Actions release workflow failed with syscall errors:
```
undefined: syscall.SYS_IOCTL
undefined: syscall.TIOCGWINSZ  
```

### Root Cause
- Unix-specific system calls used in cross-platform code
- Windows doesn't support `TIOCGWINSZ` (terminal window size) syscall
- Cross-compilation to Windows failed during automated release

### Solution

#### 🔧 Platform-Specific Implementation
- **`reader_unix.go`**: Unix syscall implementation (`//go:build \!windows`)
- **`reader_windows.go`**: Windows API implementation (`//go:build windows`)
- **`reader.go`**: Remove platform-specific code, keep common functions

#### 🏗️ Technical Details
- **Unix**: Uses `syscall.TIOCGWINSZ` for terminal size detection
- **Windows**: Uses `kernel32.dll GetConsoleScreenBufferInfo` API
- **Build Tags**: Proper conditional compilation for each platform

### ✅ Verification

#### Cross-Platform Build Success
```bash
✅ Linux (amd64): 9.6MB binary
✅ macOS (amd64): 9.5MB binary  
✅ Windows (amd64): 10.0MB binary
```

#### Runtime Testing
- Linux binary tested: `vyb version v1.0.0` ✅
- All platform binaries generate successfully
- No regression in existing functionality

### Impact
- **v1.0.1 Release**: Complete 5-platform binary distribution
- **GitHub Actions**: Will succeed with Windows support
- **User Experience**: Windows users can now install vyb-code
- **No Breaking Changes**: Existing Linux/macOS functionality unchanged

### Files Changed
- `internal/input/reader_unix.go` (new)
- `internal/input/reader_windows.go` (new) 
- `internal/input/reader.go` (platform-specific code removed)

This hotfix enables the complete multi-platform release that was intended for v1.0.0.