### PR TITLE
修正: GitHub Actions重複リリース失敗の防止

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,21 @@ jobs:
           cd dist
           sha256sum *.tar.gz *.zip > checksums.txt
 
+      - name: Check if release exists
+        id: check_release
+        run: |
+          if gh release view ${{ steps.version.outputs.VERSION }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "⚠️ Release ${{ steps.version.outputs.VERSION }} already exists, skipping creation"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "✅ Release ${{ steps.version.outputs.VERSION }} does not exist, proceeding with creation"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
+        if: steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.VERSION }}
@@ -87,5 +101,14 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/checksums.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload assets to existing release
+        if: steps.check_release.outputs.exists == 'true'
+        run: |
+          echo "📦 Uploading assets to existing release ${{ steps.version.outputs.VERSION }}"
+          gh release upload ${{ steps.version.outputs.VERSION }} dist/*.tar.gz dist/*.zip dist/checksums.txt --clobber
+          echo "✅ Assets uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🛠️ GitHub Actions リリースワークフロー問題の修正

### 問題
GitHub Actions リリースワークフローが既存リリースを作成しようとして **403エラー** で失敗：

```
⚠️ GitHub release failed with status: 403
❌ Too many retries. Aborting...
```

#### 根本原因
**手動リリース**と**自動リリース**プロセス間の**競合状態**：
1. **手動リリース**: `gh release create v1.0.1` 
2. **タグプッシュ**: `git push origin v1.0.1`
3. **GitHub Actions起動**: 自動ワークフロー実行  
4. **競合**: Actions が既存リリースの作成を試行 → 403エラー

### 解決策

#### ✅ リリース存在チェック
```yaml
- name: Check if release exists
  if gh release view $VERSION; then
    echo "exists=true" 
  else
    echo "exists=false"
  fi
```

#### ✅ 条件付きリリース作成  
```yaml
- name: Create Release
  if: steps.check_release.outputs.exists == 'false'
```

#### ✅ 既存リリースへのアセット追加
```yaml
- name: Upload assets to existing release  
  if: steps.check_release.outputs.exists == 'true'
  run: gh release upload $VERSION dist/*.tar.gz --clobber
```

### 新しい動作

| シナリオ | 動作 | 結果 |
|----------|------|------|
| **リリースが存在しない** | 新規リリース作成 + アセット追加 | ✅ 成功 |
| **リリースが存在する** | 作成スキップ、アセット追加のみ | ✅ 成功 |
| **アセット競合** | `--clobber`で上書き | ✅ 成功 |

### メリット

- **🚫 403エラーなし**: インテリジェントなリリース処理
- **🔄 両方のワークフロー対応**: 手動 + 自動リリース  
- **🎯 常に緑のCI**: GitHub Actionsで偽の失敗なし
- **📦 アセット更新**: 既存リリースのバイナリ更新
- **🛡️ 後方互換**: 既存プロセスへの破壊的変更なし

### テストシナリオ

この修正は全ての一般的なリリースシナリオに対応：
1. **純粋自動**: タグプッシュ → ワークフローがリリース作成 ✅
2. **純粋手動**: `gh release create` → 競合なし ✅  
3. **混合ワークフロー**: 手動先行、その後タグプッシュ → アセット更新 ✅
4. **再実行**: ワークフロー再実行 → 重複エラーなし ✅

成功したリリースが無害な403競合によってGitHub Actionsで"失敗"と表示される問題を解決します。