### PR TITLE
修正: リリースワークフローの権限不足を解消

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 問題
v2.0.0リリース時にGitHub Actionsで403権限エラーが発生

## 解決策
リリースワークフローに明示的な権限を追加：
- `contents: write` - リリース作成のため
- `packages: write` - パッケージ公開のため

## 確認事項
✅ 権限設定を追加してGitHub Actionsの403エラーを解決
✅ リリースプロセスが正常に動作するように修正

マージ後、v2.0.0タグを再作成してリリースを実行します。