### PR TITLE
fix: 移行完了後の設定クリーンアップ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,8 @@ go test ./internal/analysis -v -run TestCognitiveAnalyzer
 - ✅ Workspace mode restrictions
 - ✅ Security settings and command restrictions
 - ✅ Performance optimization settings
-- ✅ **Interface configuration** (deprecated TUI settings maintained for compatibility)
+- ✅ **Migration system configuration** (completed unified mode after PR#32, PR#33)
+- ✅ **Legacy TUI configuration** (deprecated - Claude Code風インターフェースが標準)
 
 **Current config commands:**
 
@@ -281,8 +282,14 @@ go test ./internal/analysis -v -run TestCognitiveAnalyzer
 vyb config list                    # Show current settings
 vyb config set-model <model>       # Set LLM model
 vyb config set-provider <provider> # Set LLM provider
-# Note: TUI configuration commands are deprecated
-# Claude Code-style interface is now the default experience
+vyb config set-migration-mode <mode> # Set migration mode (unified mode is default)
+
+# Legacy TUI configuration commands (deprecated)
+vyb config set-tui <true|false>      # TUI mode setting (deprecated)
+vyb config set-tui-theme <theme>     # TUI theme setting (deprecated)
+
+# Note: TUI configuration commands are deprecated after migration completion (PR#32, PR#33)
+# Claude Code-style interface is now the default and only supported interface
 ```
 
 **All implemented commands:**

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,11 +229,11 @@ func DefaultConfig() *Config {
 			Context:       make(map[string]string),
 		},
 		TUI: TUIConfig{
-			Enabled:      true,
-			Theme:        "vyb",
-			ShowSpinner:  true,
-			ShowProgress: true,
-			Animation:    true,
+			Enabled:      false, // レガシーTUI無効（Claude Code風UIに完全移行）
+			Theme:        "",     // 使用しない
+			ShowSpinner:  false,  // Claude Code風UIで代替
+			ShowProgress: false,  // Claude Code風UIで代替
+			Animation:    false,  // Claude Code風UIで代替
 		},
 		TerminalMode: TerminalModeConfig{
 			TypingSpeed:     15, // 15ms per character
@@ -261,23 +261,23 @@ func DefaultConfig() *Config {
 			ProjectMonitoring:  false, // 重い処理は引き続き無効
 		},
 		Migration: GradualMigrationConfig{
-			// デフォルトは段階的移行モード（安全な設定）
-			UseUnifiedStreaming: false, // 段階的に有効化
-			UseUnifiedSession:   false, // 段階的に有効化
-			UseUnifiedTools:     false, // 段階的に有効化
-			UseUnifiedAnalysis:  false, // 段階的に有効化
+			// 移行完了後のデフォルト設定（PR#32, PR#33で移行完了済み）
+			UseUnifiedStreaming: true, // 統合ストリーミング使用（移行完了）
+			UseUnifiedSession:   true, // 統合セッション管理使用（移行完了）
+			UseUnifiedTools:     true, // 統合ツールシステム使用（移行完了）
+			UseUnifiedAnalysis:  true, // 統合分析システム使用（移行完了）
 
-			MigrationMode: "gradual", // gradual, compatibility, unified
+			MigrationMode: "unified", // 統合モード（移行完了）
 
-			// 検証・監視はデフォルトで有効
-			EnableValidation:  true,
-			ValidationTimeout: 30, // 30秒
-			EnableFallback:    true,
+			// 検証・監視設定（移行完了により調整）
+			EnableValidation:  false, // 移行完了により不要
+			ValidationTimeout: 30,    // 30秒（監視用として保持）
+			EnableFallback:    false, // レガシーシステム削除により無効
 
-			// モニタリングは有効
+			// パフォーマンス監視は継続
 			EnableMetrics:    true,
 			MetricsInterval:  60, // 1分間隔
-			LogMigrationInfo: true,
+			LogMigrationInfo: false, // 移行完了により不要
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -230,10 +230,10 @@ func DefaultConfig() *Config {
 		},
 		TUI: TUIConfig{
 			Enabled:      false, // レガシーTUI無効（Claude Code風UIに完全移行）
-			Theme:        "",     // 使用しない
-			ShowSpinner:  false,  // Claude Code風UIで代替
-			ShowProgress: false,  // Claude Code風UIで代替
-			Animation:    false,  // Claude Code風UIで代替
+			Theme:        "",    // 使用しない
+			ShowSpinner:  false, // Claude Code風UIで代替
+			ShowProgress: false, // Claude Code風UIで代替
+			Animation:    false, // Claude Code風UIで代替
 		},
 		TerminalMode: TerminalModeConfig{
 			TypingSpeed:     15, // 15ms per character
@@ -276,7 +276,7 @@ func DefaultConfig() *Config {
 
 			// パフォーマンス監視は継続
 			EnableMetrics:    true,
-			MetricsInterval:  60, // 1分間隔
+			MetricsInterval:  60,    // 1分間隔
 			LogMigrationInfo: false, // 移行完了により不要
 		},
 	}

--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -158,10 +158,10 @@ func DefaultFeatureFlags() map[string]*FeatureFlag {
 		},
 		FeaturePluginArchitecture: {
 			Name:        FeaturePluginArchitecture,
-			Enabled:     false, // プラグインアーキテクチャは開発中
-			Description: "プラグインアーキテクチャ（実験的）",
+			Enabled:     true, // プラグインアーキテクチャは実装済み（PR#33）
+			Description: "プラグインスタイルアーキテクチャ基盤",
 			Version:     "3.0.0",
-			Conditions:  map[string]string{"experimental": "true"},
+			Conditions:  map[string]string{"architecture": "modular"},
 		},
 		FeatureFactoryPattern: {
 			Name:        FeatureFactoryPattern,
@@ -172,10 +172,10 @@ func DefaultFeatureFlags() map[string]*FeatureFlag {
 		},
 		FeatureModularArchitecture: {
 			Name:        FeatureModularArchitecture,
-			Enabled:     false, // モジュラーアーキテクチャは実験的
+			Enabled:     true, // モジュラーアーキテクチャは実装済み（PR#33）
 			Description: "Core/Extensions分離型モジュラーアーキテクチャ",
 			Version:     "3.0.0",
-			Conditions:  map[string]string{"experimental": "true", "architecture": "modular"},
+			Conditions:  map[string]string{"architecture": "modular"},
 		},
 	}
 }

--- a/internal/handlers/config.go
+++ b/internal/handlers/config.go
@@ -94,8 +94,8 @@ func (h *ConfigHandler) ListConfig() error {
 	fmt.Printf("  Stream: %t\n", cfg.Stream)
 	fmt.Printf("  Log Level: %s\n", cfg.Log.Level)
 	fmt.Printf("  Log Format: %s\n", cfg.Log.Format)
-	fmt.Printf("  TUI Enabled: %t\n", cfg.TUI.Enabled)
-	fmt.Printf("  TUI Theme: %s\n", cfg.TUI.Theme)
+	fmt.Printf("  TUI Enabled: %t (deprecated - Claude Code風インターフェースが標準)\n", cfg.TUI.Enabled)
+	fmt.Printf("  TUI Theme: %s (deprecated - Claude Code風インターフェースが標準)\n", cfg.TUI.Theme)
 	fmt.Printf("  File Max Size (MB): %d\n", cfg.FileMaxSizeMB)
 	fmt.Printf("  Command Timeout: %d\n", cfg.CommandTimeout)
 
@@ -403,10 +403,10 @@ func (h *ConfigHandler) CreateConfigCommands() *cobra.Command {
 		},
 	}
 
-	// set-tui コマンド
+	// set-tui コマンド（非推奨）
 	setTUICmd := &cobra.Command{
 		Use:   "set-tui [true|false]",
-		Short: "Enable or disable TUI mode",
+		Short: "Enable or disable TUI mode (deprecated - Claude Code風インターフェースが標準)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			enabled, err := strconv.ParseBool(args[0])
@@ -417,10 +417,10 @@ func (h *ConfigHandler) CreateConfigCommands() *cobra.Command {
 		},
 	}
 
-	// set-tui-theme コマンド
+	// set-tui-theme コマンド（非推奨）
 	setTUIThemeCmd := &cobra.Command{
 		Use:   "set-tui-theme [theme]",
-		Short: "Set TUI theme (dark, light, auto, vyb)",
+		Short: "Set TUI theme (deprecated - Claude Code風インターフェースが標準)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return h.SetTUITheme(args[0])


### PR DESCRIPTION
## 概要

PR#32、PR#33で段階的移行システムが完了したため、古い設定が残っていた箇所を修正し、統合システムの状態を正しく反映するように更新しました。

## 変更内容

### 設定のデフォルト値更新
- **Migration設定**: `gradual` → `unified` モードに変更
- **統合システムフラグ**: 全ての `UseUnified*` を `true` に設定（移行完了状態を反映）
- **検証・フォールバック**: 移行完了により無効化

### レガシーTUI設定の非推奨化
- TUI設定をデフォルトで無効化
- 設定表示に非推奨警告を追加
- コマンドヘルプに非推奨マークを追加

### 機能フラグの更新
- プラグインアーキテクチャフラグを有効化（実装済み）
- モジュラーアーキテクチャフラグを有効化（実装済み）

### ドキュメント更新
- CLAUDE.mdの設定説明を移行完了後の状態に更新
- TUI設定コマンドの非推奨化を明記

## 技術的詳細

### 設定ファイルの変更
- `internal/config/config.go`: デフォルト設定をunifiedモードに更新
- `internal/config/features.go`: 実装済み機能フラグを有効化
- `internal/handlers/config.go`: 非推奨警告とヘルプメッセージ更新

### 移行システムの完了状態
- 統合ストリーミング: ✅ 有効
- 統合セッション管理: ✅ 有効  
- 統合ツールシステム: ✅ 有効
- 統合分析システム: ✅ 有効

## テスト

- 設定ファイルの読み込み確認
- デフォルト設定の適用確認
- バイブコーディングモードの動作確認

## 影響範囲

- 新規インストール時のデフォルト設定
- 既存設定ファイルには影響なし（後方互換性維持）
- Claude Code風インターフェースが標準として確立

この変更により、移行システムの完了状態が正しく反映され、新しいユーザーには統合システムが標準として提供されます。